### PR TITLE
CI: various updates

### DIFF
--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -1,6 +1,7 @@
 name: linux
 
-on: [push, pull_request]
+on: [pull_request]
+#on: [push, pull_request]
 
 jobs:
   arduino_ci:
@@ -8,7 +9,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: Arduino-CI/action@v0.1.0
+      - uses: Arduino-CI/action@stable-1.x
         env:
           # Not all libraries are in the root directory of a repository.
           # Specifying the path of the library here (relative to the root
@@ -45,4 +46,4 @@ jobs:
           # within the Arduino libraries directory; you should NOT attempt
           # to find that directory nor change to it from within the script.
           #
-          CUSTOM_INIT_SCRIPT: scripts/Arduino-CI--pre-init.sh
+          CUSTOM_INIT_SCRIPT: scripts/Arduino-CI--init.sh

--- a/.github/workflows/macos.yaml
+++ b/.github/workflows/macos.yaml
@@ -1,6 +1,7 @@
 name: macos
 
-on: [push, pull_request]
+on: [pull_request]
+#on: [push, pull_request]
 
 jobs:
   runTest: 
@@ -13,3 +14,40 @@ jobs:
       - run: |
           bundle install
           bundle exec arduino_ci.rb
+        env:
+          # Not all libraries are in the root directory of a repository.
+          # Specifying the path of the library here (relative to the root
+          # of the repository) will adjust that.
+          #
+          # The default is the current directory
+          #
+          USE_SUBDIR: .
+
+          # Not all libraries include examples or unit tests.  The default
+          #  behavior of arduino_ci is to assume that "if the files don't
+          #  exist, then they were not MEANT to exist".  In other words,
+          #  if you were to accidentally delete all your tests or example
+          #  sketches, then the CI runner would by default assume that was
+          #  intended and return a passing result.
+          #
+          # If you'd rather have the test runner fail the test in the
+          #  absence of either tests or examples, uncommenting either of
+          #  the following variables to 'true' (as appropriate) will
+          #  enforce that.
+          #
+          EXPECT_EXAMPLES: true
+          EXPECT_UNITTESTS: true
+
+          # Although dependencies will be installed automatically via the
+          # library manager, your library under test may require an
+          # unofficial version of a dependency.  In those cases, the custom
+          # libraries must be insalled prior to the test execution; those
+          # installation commands should be placed in a shell script (that
+          # will be executed by /bin/sh) stored in your library.
+          #
+          # Then, set this variable to the path to that file (relative to
+          # the root of your repository).  The script will be run from
+          # within the Arduino libraries directory; you should NOT attempt
+          # to find that directory nor change to it from within the script.
+          #
+          CUSTOM_INIT_SCRIPT: scripts/Arduino-CI--init.sh

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -1,6 +1,7 @@
 name: windows
 
-on: [push, pull_request]
+on: [pull_request]
+#on: [push, pull_request]
 
 jobs:
   runTest: 
@@ -13,3 +14,40 @@ jobs:
       - run: |
           bundle install
           bundle exec arduino_ci.rb
+        env:
+          # Not all libraries are in the root directory of a repository.
+          # Specifying the path of the library here (relative to the root
+          # of the repository) will adjust that.
+          #
+          # The default is the current directory
+          #
+          USE_SUBDIR: .
+
+          # Not all libraries include examples or unit tests.  The default
+          #  behavior of arduino_ci is to assume that "if the files don't
+          #  exist, then they were not MEANT to exist".  In other words,
+          #  if you were to accidentally delete all your tests or example
+          #  sketches, then the CI runner would by default assume that was
+          #  intended and return a passing result.
+          #
+          # If you'd rather have the test runner fail the test in the
+          #  absence of either tests or examples, uncommenting either of
+          #  the following variables to 'true' (as appropriate) will
+          #  enforce that.
+          #
+          EXPECT_EXAMPLES: true
+          EXPECT_UNITTESTS: true
+
+          # Although dependencies will be installed automatically via the
+          # library manager, your library under test may require an
+          # unofficial version of a dependency.  In those cases, the custom
+          # libraries must be insalled prior to the test execution; those
+          # installation commands should be placed in a shell script (that
+          # will be executed by /bin/sh) stored in your library.
+          #
+          # Then, set this variable to the path to that file (relative to
+          # the root of your repository).  The script will be run from
+          # within the Arduino libraries directory; you should NOT attempt
+          # to find that directory nor change to it from within the script.
+          #
+          CUSTOM_INIT_SCRIPT: scripts/Arduino-CI--init.sh

--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=CATEGORY
 url=https://github.com/autonomousrobotshq/Spine--Sensors
 architectures=avr
 includes=Sensor.hpp, SensorCurrent.hpp, SensorGPS.hpp, SensorHall.hpp, SensorIMU.hpp, SensorTemp.hpp, SensorUltrasonic.hpp
-depends=s-t-a-n--Structures, Spine--Filters, Spine--Timers, Spine--ROS-Generated, Spine--TinyGPS, Spine--LSM303, Spine--OneWire, Spine--DallasTemperature
+depends=s-t-a-n--Structures, Spine--Filters, Spine--Timers, Spine--ROS-Generated, TinyGPS, LSM303, OneWire, DallasTemperature

--- a/scripts/Arduino-CI--init.sh
+++ b/scripts/Arduino-CI--init.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# pull in external repositories
+git clone https://github.com/s-t-a-n/Structures.git s-t-a-n--Structures
+
+# pull in internal repositories
+git clone https://github.com/autonomousrobotshq/Spine--Filters
+git clone https://github.com/autonomousrobotshq/Spine--Timers
+git clone https://github.com/autonomousrobotshq/Spine--ROS-Generated
+git clone https://github.com/autonomousrobotshq/TinyGPS
+git clone https://github.com/autonomousrobotshq/LSM303
+git clone https://github.com/autonomousrobotshq/OneWire
+git clone https://github.com/autonomousrobotshq/DallasTemperature

--- a/scripts/Arduino-CI--pre-init.sh
+++ b/scripts/Arduino-CI--pre-init.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-# pull in Structures repo
-git clone https://github.com/s-t-a-n/Structures.git s-t-a-n--Structures


### PR DESCRIPTION
Bumped github ubuntu workflow: Arduino-CI/action@v0.1.0 -> Arduino-CI/action@stable-1.x

Renamed: scripts/Arduino-CI--pre-init.sh -> scripts/Arduino-CI--init.sh

Added all dependencies in /scripts/Arduino-CI--init.sh

Updated dependencies in library.properties

Added init script to MacOS test

Added init script to Windows test

Disabled testing on pushes